### PR TITLE
Fix contacts test class

### DIFF
--- a/tests/Endpoints/ContactsTest.php
+++ b/tests/Endpoints/ContactsTest.php
@@ -2,7 +2,7 @@
 
 use SunAsterisk\Chatwork\Endpoints\Contacts;
 
-class StatusTest extends TestCase
+class ContactsTest extends TestCase
 {
     public function testMe()
     {


### PR DESCRIPTION
The `tests/Endpoints/ContactsTest.php` file is holding wrong class name called `StatusTest`. This PR renames it the ContactsTest.