### PR TITLE
Add withApiToken and withAccessToken methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Create a chatwork client with an api token or an access token:
 
 use SunAsterisk\Chatwork\Chatwork;
 
-$chatwork = Chatwork::fromApiToken('your-api-token');
+$chatwork = Chatwork::withAPIToken('your-api-token');
 
-// $chatwork = Chatwork::fromAccessToken('your-access-token');
+// $chatwork = Chatwork::withAccessToken('your-access-token');
 ```
 
 Use chatwork client methods as these examples below:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 [![Build Status](https://travis-ci.org/sun-asterisk-research/chatwork-php.svg?branch=master)](https://travis-ci.org/sun-asterisk-research/chatwork-php)
 [![Latest Stable Version](https://poser.pugx.org/sun-asterisk/chatwork-php/v/stable)](https://packagist.org/packages/sun-asterisk/chatwork-php)
 [![Codecov](https://img.shields.io/codecov/c/github/sun-asterisk-research/chatwork-php)](https://codecov.io/gh/sun-asterisk-research/chatwork-php)
+![GitHub](https://img.shields.io/github/license/sun-asterisk-research/chatwork-php.svg)
 
-## Requirement
+## Requirements
 
 - PHP >= 7.0
 - PHP cURL
@@ -19,29 +20,34 @@ composer require sun-asterisk/chatwork-php
 
 ## Usage
 
-First register an API Token [here](https://www.chatwork.com/service/packages/chatwork/subpackages/api/token.php).
+You may register an API Token [here](https://www.chatwork.com/service/packages/chatwork/subpackages/api/token.php).
 
-Here're some basic usage.
+Create a chatwork client with an api token or an access token:
 
 ```php
-// Create an authentication object, authentication using API token and OAuth access token are supported
-$auth = new SunAsterisk\Chatwork\Auth\APIToken('your token');
 
-// Create an API client instance
-$chatwork = new SunAsterisk\Chatwork\Chatwork($auth);
+use SunAsterisk\Chatwork\Chatwork;
 
-// Call the API you need
+$chatwork = Chatwork::fromApiToken('your-api-token');
+
+// $chatwork = Chatwork::fromAccessToken('your-access-token');
+```
+
+Use chatwork client methods as these examples below:
+
+```php
+
+// Get your personal information.
 $me = $chatwork->me();
 
-print_r($me);
+// Get your personal tasks.
+$tasks = $chatwork->my()->tasks();
+
+// Get members in a room.
+$members = $chatwork->room($roomId)->members();
 ```
 
 API methods are organized similar to the [official API doc](http://developer.chatwork.com/ja/endpoints.html) e.g.
-
-```php
-$tasks = $chatwork->my()->tasks();
-$messages = $chatwork->room($roomId)->members();
-```
 
 ## Message builder
 

--- a/src/Chatwork.php
+++ b/src/Chatwork.php
@@ -50,7 +50,7 @@ class Chatwork
      * @param string $token
      * @return static
      */
-    public static function fromApiToken(string $token)
+    public static function withAPIToken(string $token)
     {
         return new static(new APIToken($token));
     }
@@ -61,7 +61,7 @@ class Chatwork
      * @param string $token
      * @return static
      */
-    public static function fromAccessToken(string $token)
+    public static function withAccessToken(string $token)
     {
         return new static(new AccessToken($token));
     }

--- a/src/Chatwork.php
+++ b/src/Chatwork.php
@@ -3,11 +3,13 @@
 namespace SunAsterisk\Chatwork;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Exception\ClientException;
 use SunAsterisk\Chatwork\Auth\Auth;
-use SunAsterisk\Chatwork\Exceptions\APIException;
-use SunAsterisk\Chatwork\Helpers\Message;
 use function GuzzleHttp\json_decode;
+use SunAsterisk\Chatwork\Auth\APIToken;
+use GuzzleHttp\Exception\ClientException;
+use SunAsterisk\Chatwork\Helpers\Message;
+use SunAsterisk\Chatwork\Auth\AccessToken;
+use SunAsterisk\Chatwork\Exceptions\APIException;
 
 /**
  * @method array me()
@@ -40,6 +42,28 @@ class Chatwork
                 'Accept' => 'application/json',
             ], $auth->getHeaders()),
         ]);
+    }
+
+    /**
+     * Create a new Chatwork client instance via an api token.
+     *
+     * @param string $token
+     * @return static
+     */
+    public static function fromApiToken(string $token)
+    {
+        return new static(new APIToken($token));
+    }
+
+    /**
+     * Create a new Chatwork client instance via an access token.
+     *
+     * @param string $token
+     * @return static
+     */
+    public static function fromAccessToken(string $token)
+    {
+        return new static(new AccessToken($token));
     }
 
     public function __call($name, $arguments)

--- a/tests/ChatworkTest.php
+++ b/tests/ChatworkTest.php
@@ -167,7 +167,7 @@ class ChatworkTest extends TestCase
 
     public function testFromApiTokenMethod()
     {
-        $chatwork = Chatwork::fromAccessToken('an-api-token');
+        $chatwork = Chatwork::fromApiToken('an-api-token');
         $this->assertInstanceOf(Chatwork::class, $chatwork);
     }
 

--- a/tests/ChatworkTest.php
+++ b/tests/ChatworkTest.php
@@ -165,15 +165,15 @@ class ChatworkTest extends TestCase
         $this->assertContains('secret', $request->getHeader('X-ChatworkToken'));
     }
 
-    public function testFromApiTokenMethod()
+    public function testWithAPITokenMethod()
     {
-        $chatwork = Chatwork::fromApiToken('an-api-token');
+        $chatwork = Chatwork::withAPIToken('an-api-token');
         $this->assertInstanceOf(Chatwork::class, $chatwork);
     }
 
-    public function testFromAccessTokenMethod()
+    public function testWithAccessTokenMethod()
     {
-        $chatwork = Chatwork::fromAccessToken('an-access-token');
+        $chatwork = Chatwork::withAccessToken('an-access-token');
         $this->assertInstanceOf(Chatwork::class, $chatwork);
     }
 

--- a/tests/ChatworkTest.php
+++ b/tests/ChatworkTest.php
@@ -165,6 +165,18 @@ class ChatworkTest extends TestCase
         $this->assertContains('secret', $request->getHeader('X-ChatworkToken'));
     }
 
+    public function testFromApiTokenMethod()
+    {
+        $chatwork = Chatwork::fromAccessToken('an-api-token');
+        $this->assertInstanceOf(Chatwork::class, $chatwork);
+    }
+
+    public function testFromAccessTokenMethod()
+    {
+        $chatwork = Chatwork::fromAccessToken('an-access-token');
+        $this->assertInstanceOf(Chatwork::class, $chatwork);
+    }
+
     protected function getInstanceMock($responses, &$history)
     {
         $api = new Chatwork($this->getAuth());


### PR DESCRIPTION
It's more convenience when hiding initiate of chatwork client. The developers don't have to care about the dependencies. Just give a token and relax. I have updated `README.md` file.

Let's see how clear the code sample is!
```php
use SunAsterisk\Chatwork\Chatwork;

$chatwork = Chatwork::withAPIToken('an-api-token');
// $chatwork = Chatwork::withAccessToken('an-access-token');

$me = $chatwork->me();
print_r($me);
```